### PR TITLE
chore(ci): build-test pipeline & release prebuilt images

### DIFF
--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -101,7 +101,10 @@ jobs:
           docker tag ${{ env.IMAGE_NAME_NAKAMA }}:latest $IMAGE_ID_NAKAMA:$VERSION
           docker tag ${{ env.IMAGE_NAME_CARDINAL }}:latest $IMAGE_ID_CARDINAL:$VERSION
           docker tag ${{ env.IMAGE_NAME_TESTSUITE }}:latest $IMAGE_ID_TESTSUITE:$VERSION
-          docker push $IMAGE_ID:$VERSION
+
+          docker push $IMAGE_ID_NAKAMA:$VERSION
+          docker push $IMAGE_ID_CARDINAL:$VERSION
+          docker push $IMAGE_ID_TESTSUITE:$VERSION
   artifact-cleanup:
     runs-on: ubuntu-latest
     needs: [

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -13,9 +13,10 @@ on:
       - 'v*.*.*'
 
 env:
-  IMAGE_NAME_NAKAMA: starter-game-template-nakama
-  IMAGE_NAME_CARDINAL: starter-game-template-cardinal
-  IMAGE_NAME_TESTSUITE: starter-game-template-testsuite
+  IMAGE_NAME_NAKAMA: starter-game-template/nakama
+  IMAGE_NAME_CARDINAL: starter-game-template/cardinal
+  IMAGE_NAME_TESTSUITE: starter-game-template/testsuite
+  REGISTRY_URL: us-docker.pkg.dev
   
 jobs:
   mage-build-test:
@@ -81,22 +82,34 @@ jobs:
           docker load --input /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
           docker load --input /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
           docker image ls -a | grep starter-game-template
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: GCP auth
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      - name: GCP - Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+      - name: Docker - auth to artifact registry
+        run: |
+          gcloud auth configure-docker ${{ env.REGISTRY_URL }}
       - name: Push image
         run: |
-          IMAGE_ID_NAKAMA=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME_NAKAMA }}
+          IMAGE_ID_NAKAMA=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_NAKAMA }}
           IMAGE_ID_NAKAMA=$(echo $IMAGE_ID_NAKAMA | tr '[A-Z]' '[a-z]')
 
-          IMAGE_ID_CARDINAL=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME_CARDINAL }}
+          IMAGE_ID_CARDINAL=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_CARDINAL }}
           IMAGE_ID_CARDINAL=$(echo $IMAGE_ID_CARDINAL | tr '[A-Z]' '[a-z]')
 
-          IMAGE_ID_TESTSUITE=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME_TESTSUITE }}
+          IMAGE_ID_TESTSUITE=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_TESTSUITE }}
           IMAGE_ID_TESTSUITE=$(echo $IMAGE_ID_TESTSUITE | tr '[A-Z]' '[a-z]')
 
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           [ "$VERSION" == "main" ] && VERSION=latest
+          [ "$VERSION" == "merge" ] && VERSION=latest
 
           docker tag ${{ env.IMAGE_NAME_NAKAMA }}:latest $IMAGE_ID_NAKAMA:$VERSION
           docker tag ${{ env.IMAGE_NAME_CARDINAL }}:latest $IMAGE_ID_CARDINAL:$VERSION

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -33,6 +33,14 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Mage - check
         uses: magefile/mage-action@v2
         with:
@@ -63,6 +71,10 @@ jobs:
     defaults:
       run:
         shell: bash
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -50,9 +50,9 @@ jobs:
           docker image ls -a | grep starter-game-template
       - name: Docker save local build images
         run: |
-          docker save IMAGE_NAME_NAKAMA:latest > /tmp/IMAGE_NAME_NAKAMA-latest.tar
-          docker save IMAGE_NAME_CARDINAL:latest > /tmp/IMAGE_NAME_CARDINAL-latest.tar
-          docker save IMAGE_NAME_TESTSUITE:latest > /tmp/IMAGE_NAME_TESTSUITE-latest.tar
+          docker save ${{ env.IMAGE_NAME_NAKAMA:latest }} > /tmp/${{ env.IMAGE_NAME_NAKAMA }}-latest.tar
+          docker save ${{ env.IMAGE_NAME_CARDINAL:latest }} > /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
+          docker save ${{ env.IMAGE_NAME_TESTSUITE:latest }} > /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
       - name: Upload local build images to temporary artifact
         uses: actions/upload-artifact@v3
         with:
@@ -77,26 +77,30 @@ jobs:
           path: /tmp/
       - name: Load image and show build images
         run: |
-          docker load --input /tmp/IMAGE_NAME_NAKAMA-latest.tar
-          docker load --input /tmp/IMAGE_NAME_CARDINAL-latest.tar
-          docker load --input /tmp/IMAGE_NAME_TESTSUITE-latest.tar
+          docker load --input /tmp/${{ env.IMAGE_NAME_NAKAMA }}-latest.tar
+          docker load --input /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
+          docker load --input /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
           docker image ls -a | grep starter-game-template
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Push image
         run: |
-          IMAGE_ID_NAKAMA=ghcr.io/${{ github.repository_owner }}/IMAGE_NAME_NAKAMA
+          IMAGE_ID_NAKAMA=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME_NAKAMA }}
           IMAGE_ID_NAKAMA=$(echo $IMAGE_ID_NAKAMA | tr '[A-Z]' '[a-z]')
-          IMAGE_ID_CARDINAL=ghcr.io/${{ github.repository_owner }}/IMAGE_NAME_CARDINAL
+
+          IMAGE_ID_CARDINAL=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME_CARDINAL }}
           IMAGE_ID_CARDINAL=$(echo $IMAGE_ID_CARDINAL | tr '[A-Z]' '[a-z]')
-          IMAGE_ID_TESTSUITE=ghcr.io/${{ github.repository_owner }}/IMAGE_NAME_TESTSUITE
+
+          IMAGE_ID_TESTSUITE=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME_TESTSUITE }}
           IMAGE_ID_TESTSUITE=$(echo $IMAGE_ID_TESTSUITE | tr '[A-Z]' '[a-z]')
+
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           [ "$VERSION" == "main" ] && VERSION=latest
-          docker tag $IMAGE_NAME_NAKAMA:latest $IMAGE_ID_NAKAMA:$VERSION
-          docker tag $IMAGE_NAME_CARDINAL:latest $IMAGE_ID_CARDINAL:$VERSION
-          docker tag $IMAGE_NAME_TESTSUITE:latest $IMAGE_ID_TESTSUITE:$VERSION
+
+          docker tag ${{ env.IMAGE_NAME_NAKAMA }}:latest $IMAGE_ID_NAKAMA:$VERSION
+          docker tag ${{ env.IMAGE_NAME_CARDINAL }}:latest $IMAGE_ID_CARDINAL:$VERSION
+          docker tag ${{ env.IMAGE_NAME_TESTSUITE }}:latest $IMAGE_ID_TESTSUITE:$VERSION
           docker push $IMAGE_ID:$VERSION
   artifact-cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -13,9 +13,6 @@ on:
       - 'v*.*.*'
 
 env:
-  IMAGE_NAME_NAKAMA: starter-game-template/nakama
-  IMAGE_NAME_CARDINAL: starter-game-template/cardinal
-  IMAGE_NAME_TESTSUITE: starter-game-template/testsuite
   REGISTRY_URL: us-docker.pkg.dev
   
 jobs:
@@ -51,9 +48,9 @@ jobs:
           docker image ls -a | grep starter-game-template
       - name: Docker save local build images
         run: |
-          docker save ${{ env.IMAGE_NAME_NAKAMA }}:latest > /tmp/${{ env.IMAGE_NAME_NAKAMA }}-latest.tar
-          docker save ${{ env.IMAGE_NAME_CARDINAL }}:latest > /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
-          docker save ${{ env.IMAGE_NAME_TESTSUITE }}:latest > /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
+          docker save ${{ github.event.repository.name }}-nakama:latest > /tmp/${{ github.event.repository.name }}-nakama-latest.tar
+          docker save ${{ github.event.repository.name }}-cardinal:latest > /tmp/${{ github.event.repository.name }}-cardinal-latest.tar
+          docker save ${{ github.event.repository.name }}-testsuite:latest > /tmp/${{ github.event.repository.name }}-testsuite-latest.tar
       - name: Upload local build images to temporary artifact
         uses: actions/upload-artifact@v3
         with:
@@ -78,9 +75,9 @@ jobs:
           path: /tmp/
       - name: Load image and show build images
         run: |
-          docker load --input /tmp/${{ env.IMAGE_NAME_NAKAMA }}-latest.tar
-          docker load --input /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
-          docker load --input /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
+          docker load --input /tmp/${{ github.event.repository.name }}-nakama-latest.tar
+          docker load --input /tmp/${{ github.event.repository.name }}-cardinal-latest.tar
+          docker load --input /tmp/${{ github.event.repository.name }}-testsuite-latest.tar
           docker image ls -a | grep starter-game-template
       - name: GCP auth
         id: auth
@@ -97,13 +94,13 @@ jobs:
           gcloud auth configure-docker ${{ env.REGISTRY_URL }}
       - name: Push image
         run: |
-          IMAGE_ID_NAKAMA=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_NAKAMA }}
+          IMAGE_ID_NAKAMA=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ github.event.repository.name }}/nakama
           IMAGE_ID_NAKAMA=$(echo $IMAGE_ID_NAKAMA | tr '[A-Z]' '[a-z]')
 
-          IMAGE_ID_CARDINAL=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_CARDINAL }}
+          IMAGE_ID_CARDINAL=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ github.event.repository.name }}/cardinal
           IMAGE_ID_CARDINAL=$(echo $IMAGE_ID_CARDINAL | tr '[A-Z]' '[a-z]')
 
-          IMAGE_ID_TESTSUITE=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_TESTSUITE }}
+          IMAGE_ID_TESTSUITE=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ github.event.repository.name }}/testsuite
           IMAGE_ID_TESTSUITE=$(echo $IMAGE_ID_TESTSUITE | tr '[A-Z]' '[a-z]')
 
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
@@ -111,9 +108,9 @@ jobs:
           [ "$VERSION" == "main" ] && VERSION=latest
           [ "$VERSION" == "merge" ] && VERSION=latest
 
-          docker tag ${{ env.IMAGE_NAME_NAKAMA }}:latest $IMAGE_ID_NAKAMA:$VERSION
-          docker tag ${{ env.IMAGE_NAME_CARDINAL }}:latest $IMAGE_ID_CARDINAL:$VERSION
-          docker tag ${{ env.IMAGE_NAME_TESTSUITE }}:latest $IMAGE_ID_TESTSUITE:$VERSION
+          docker tag ${{ github.event.repository.name }}-nakama:latest $IMAGE_ID_NAKAMA:$VERSION
+          docker tag ${{ github.event.repository.name }}-cardinal:latest $IMAGE_ID_CARDINAL:$VERSION
+          docker tag ${{ github.event.repository.name }}-testsuite:latest $IMAGE_ID_TESTSUITE:$VERSION
 
           docker push $IMAGE_ID_NAKAMA:$VERSION
           docker push $IMAGE_ID_CARDINAL:$VERSION

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -13,11 +13,12 @@ on:
       - 'v*.*.*'
 
 env:
-  CARDINAL_REGISTRY_PATH: starter-game-template/cardinal
-  NAKAMA_REGISTRY_PATH: starter-game-templa/nakama
+  IMAGE_NAME_NAKAMA: starter-game-template-nakama
+  IMAGE_NAME_CARDINAL: starter-game-template-cardinal
+  IMAGE_NAME_TESTSUITE: starter-game-template-testsuite
   
 jobs:
-  mage-build:
+  mage-build-test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,51 +40,73 @@ jobs:
         with:
           version: latest
           args: check
-      - name: Mage - build
-        uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: build
-  mage-test:
-    runs-on: ubuntu-latest
-    needs: mage-build
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        go-version: [1.20.x]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: Mage - check
-        uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: check
-      - name: Mage - test
+      - name: Mage - build & test
         uses: magefile/mage-action@v2
         with:
           version: latest
           args: test
+      - name: Docker show build images
+        run: |
+          docker image ls -a | grep starter-game-template
+      - name: Docker save local build images
+        run: |
+          docker save IMAGE_NAME_NAKAMA:latest > /tmp/IMAGE_NAME_NAKAMA-latest.tar
+          docker save IMAGE_NAME_CARDINAL:latest > /tmp/IMAGE_NAME_CARDINAL-latest.tar
+          docker save IMAGE_NAME_TESTSUITE:latest > /tmp/IMAGE_NAME_TESTSUITE-latest.tar
+      - name: Upload local build images to temporary artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: buildimage
+          path: /tmp/starter-game-template-*.tar
   images-release:
     runs-on: ubuntu-latest
-    needs: mage-build
+    needs: mage-build-test
+#    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     defaults:
       run:
         shell: bash
-    strategy:
-      matrix:
-        go-version: [1.20.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - run: docker images
+      - name: Download local build images artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: buildimage
+          path: /tmp/
+      - name: Load image and show build images
+        run: |
+          docker load --input /tmp/IMAGE_NAME_NAKAMA-latest.tar
+          docker load --input /tmp/IMAGE_NAME_CARDINAL-latest.tar
+          docker load --input /tmp/IMAGE_NAME_TESTSUITE-latest.tar
+          docker image ls -a | grep starter-game-template
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID_NAKAMA=ghcr.io/${{ github.repository_owner }}/IMAGE_NAME_NAKAMA
+          IMAGE_ID_NAKAMA=$(echo $IMAGE_ID_NAKAMA | tr '[A-Z]' '[a-z]')
+          IMAGE_ID_CARDINAL=ghcr.io/${{ github.repository_owner }}/IMAGE_NAME_CARDINAL
+          IMAGE_ID_CARDINAL=$(echo $IMAGE_ID_CARDINAL | tr '[A-Z]' '[a-z]')
+          IMAGE_ID_TESTSUITE=ghcr.io/${{ github.repository_owner }}/IMAGE_NAME_TESTSUITE
+          IMAGE_ID_TESTSUITE=$(echo $IMAGE_ID_TESTSUITE | tr '[A-Z]' '[a-z]')
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "main" ] && VERSION=latest
+          docker tag $IMAGE_NAME_NAKAMA:latest $IMAGE_ID_NAKAMA:$VERSION
+          docker tag $IMAGE_NAME_CARDINAL:latest $IMAGE_ID_CARDINAL:$VERSION
+          docker tag $IMAGE_NAME_TESTSUITE:latest $IMAGE_ID_TESTSUITE:$VERSION
+          docker push $IMAGE_ID:$VERSION
+  artifact-cleanup:
+    runs-on: ubuntu-latest
+    needs: [
+      mage-build-test,
+      images-release
+    ]
+    if: always()
+    steps:
+      - name: Remove local build image artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: buildimage

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -55,11 +55,13 @@ jobs:
         run: |
           docker image ls -a | grep starter-game-template
       - name: Docker save local build images
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
         run: |
           docker save ${{ github.event.repository.name }}-nakama:latest | gzip > /tmp/${{ github.event.repository.name }}-nakama-latest.tar.gz
           docker save ${{ github.event.repository.name }}-cardinal:latest | gzip > /tmp/${{ github.event.repository.name }}-cardinal-latest.tar.gz
           docker save ${{ github.event.repository.name }}-testsuite:latest | gzip > /tmp/${{ github.event.repository.name }}-testsuite-latest.tar.gz
       - name: Upload local build images to temporary artifact
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3
         with:
           name: buildimage
@@ -67,7 +69,7 @@ jobs:
   images-release:
     runs-on: ubuntu-latest
     needs: mage-build-test
-#    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     defaults:
       run:
         shell: bash

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -56,14 +56,14 @@ jobs:
           docker image ls -a | grep starter-game-template
       - name: Docker save local build images
         run: |
-          docker save ${{ github.event.repository.name }}-nakama:latest > /tmp/${{ github.event.repository.name }}-nakama-latest.tar
-          docker save ${{ github.event.repository.name }}-cardinal:latest > /tmp/${{ github.event.repository.name }}-cardinal-latest.tar
-          docker save ${{ github.event.repository.name }}-testsuite:latest > /tmp/${{ github.event.repository.name }}-testsuite-latest.tar
+          docker save ${{ github.event.repository.name }}-nakama:latest | gzip > /tmp/${{ github.event.repository.name }}-nakama-latest.tar.gz
+          docker save ${{ github.event.repository.name }}-cardinal:latest | gzip > /tmp/${{ github.event.repository.name }}-cardinal-latest.tar.gz
+          docker save ${{ github.event.repository.name }}-testsuite:latest | gzip > /tmp/${{ github.event.repository.name }}-testsuite-latest.tar.gz
       - name: Upload local build images to temporary artifact
         uses: actions/upload-artifact@v3
         with:
           name: buildimage
-          path: /tmp/starter-game-template-*.tar
+          path: /tmp/starter-game-template-*.tar.gz
   images-release:
     runs-on: ubuntu-latest
     needs: mage-build-test
@@ -87,9 +87,9 @@ jobs:
           path: /tmp/
       - name: Load image and show build images
         run: |
-          docker load --input /tmp/${{ github.event.repository.name }}-nakama-latest.tar
-          docker load --input /tmp/${{ github.event.repository.name }}-cardinal-latest.tar
-          docker load --input /tmp/${{ github.event.repository.name }}-testsuite-latest.tar
+          docker load --input /tmp/${{ github.event.repository.name }}-nakama-latest.tar.gz
+          docker load --input /tmp/${{ github.event.repository.name }}-cardinal-latest.tar.gz
+          docker load --input /tmp/${{ github.event.repository.name }}-testsuite-latest.tar.gz
           docker image ls -a | grep starter-game-template
       - name: GCP auth
         id: auth

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -12,7 +12,6 @@ on:
     tags:
       - 'v*.*.*'
 
-  
 env:
   CARDINAL_REGISTRY_PATH: starter-game-template/cardinal
   NAKAMA_REGISTRY_PATH: starter-game-templa/nakama
@@ -73,3 +72,18 @@ jobs:
         with:
           version: latest
           args: test
+  images-release:
+    runs-on: ubuntu-latest
+    needs: mage-build
+    efaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - run: docker images

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -75,7 +75,7 @@ jobs:
   images-release:
     runs-on: ubuntu-latest
     needs: mage-build
-    efaults:
+    defaults:
       run:
         shell: bash
     strategy:

--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -50,9 +50,9 @@ jobs:
           docker image ls -a | grep starter-game-template
       - name: Docker save local build images
         run: |
-          docker save ${{ env.IMAGE_NAME_NAKAMA:latest }} > /tmp/${{ env.IMAGE_NAME_NAKAMA }}-latest.tar
-          docker save ${{ env.IMAGE_NAME_CARDINAL:latest }} > /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
-          docker save ${{ env.IMAGE_NAME_TESTSUITE:latest }} > /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
+          docker save ${{ env.IMAGE_NAME_NAKAMA }}:latest > /tmp/${{ env.IMAGE_NAME_NAKAMA }}-latest.tar
+          docker save ${{ env.IMAGE_NAME_CARDINAL }}:latest > /tmp/${{ env.IMAGE_NAME_CARDINAL }}-latest.tar
+          docker save ${{ env.IMAGE_NAME_TESTSUITE }}:latest > /tmp/${{ env.IMAGE_NAME_TESTSUITE }}-latest.tar
       - name: Upload local build images to temporary artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/mage-pipeline.yaml
+++ b/.github/workflows/mage-pipeline.yaml
@@ -14,10 +14,8 @@ on:
 
   
 env:
-  GCP_REGISTRY_ARTIFACT_PATH: us-docker.pkg.dev/world-engine-test/dark-forest
-  GCP_PROJECT_ID: world-engine-test
-  CARDINAL_REGISTRY_PATH: dark-forest/cardinal
-  NAKAMA_REGISTRY_PATH: dark-forest/nakama
+  CARDINAL_REGISTRY_PATH: starter-game-template/cardinal
+  NAKAMA_REGISTRY_PATH: starter-game-templa/nakama
   
 jobs:
   mage-build:

--- a/.github/workflows/mage-pipeline.yaml
+++ b/.github/workflows/mage-pipeline.yaml
@@ -1,0 +1,77 @@
+name: template-mage-pipeline
+
+## workflow will trigger on below condition,
+## except image release that have jobs condition to trigger only on tagging
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+  
+env:
+  GCP_REGISTRY_ARTIFACT_PATH: us-docker.pkg.dev/world-engine-test/dark-forest
+  GCP_PROJECT_ID: world-engine-test
+  CARDINAL_REGISTRY_PATH: dark-forest/cardinal
+  NAKAMA_REGISTRY_PATH: dark-forest/nakama
+  
+jobs:
+  mage-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Mage - check
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: check
+      - name: Mage - build
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: build
+  mage-test:
+    runs-on: ubuntu-latest
+    needs: mage-build
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Mage - check
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: check
+      - name: Mage - test
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: test

--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ Alternatively, killing the `mage start` process will also stop Nakama and Cardin
 Note, for now, if any Cardinal endpoints have been added or removed Nakama must be relaunched (via `mage stop` and `mage start`).
 We will add a future to hot reload this in the future.
 
+# Running with the prebuilt Docker Images
+
+Prerequisites:
+- Docker installed
+
+Docker Images Container Registry URLs:
+- Cardinal: `us-docker.pkg.dev/argus-labs/starter-game-template/cardinal:<latest/tag_version>`
+- Nakama: `us-docker.pkg.dev/argus-labs/starter-game-template/nakama:<latest/tag_version>`
+
+
+To start the starter-game-template Nakama and Cardinal with prebuilt Docker Images:
+
+```bash
+docker compose -f docker-compose-prebuilt.yml up --detach --wait
+```
+
+To check the services status & logs:
+
+```bash
+docker compose -f docker-compose-prebuilt.yml ps
+docker compose -f docker-compose-prebuilt.yml logs
+```
+
+To stop Nakama and Cardinal:
+```bash
+docker compose -f docker-compose-prebuilt.yml down
+```
+
 # Verify the Server is Running
 
 Visit `localhost:7351` in a web browser to access Nakama. For local development, use `admin:password` as your login

--- a/cardinal/Dockerfile
+++ b/cardinal/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20 AS builder
 
 WORKDIR /usr/src/app
 
@@ -6,6 +6,9 @@ copy . .
 copy vendor vendor/
 
 RUN go build -v -o /usr/local/bin/app
+
+FROM ubuntu:22.04
+COPY --from=builder /usr/local/bin/app /usr/local/bin/
 
 CMD ["app"]
 

--- a/docker-compose-prebuilt.yml
+++ b/docker-compose-prebuilt.yml
@@ -1,0 +1,74 @@
+version: "3"
+services:
+  postgres:
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
+    environment:
+      - POSTGRES_DB=nakama
+      - POSTGRES_PASSWORD=localdb
+    expose:
+      - "5432"
+    image: postgres:12.2-alpine
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "nakama"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
+    volumes:
+      - data:/var/lib/postgresql/data
+  redis: # This doesn't have the correct persistence settings. Don't use on for prod.
+    image: redis:latest
+    command: redis-server # TODO: This runs without password. Don't use for prod.
+    expose:
+      - "6379"
+    ports:
+      - "6379:6379"
+    restart: always
+  cardinal:
+    image: us-docker.pkg.dev/argus-labs/starter-game-template/cardinal:${STARTER_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      - redis
+    expose:
+      - "3333"
+    ports:
+      - "3333:3333"
+    environment:
+      - CARDINAL_PORT=3333
+      - REDIS_ADDR=redis:6379
+      - REDIS_MODE=normal
+  nakama:
+    image: us-docker.pkg.dev/argus-labs/starter-game-template/nakama:${STARTER_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      - postgres
+      - cardinal
+    environment:
+      - CARDINAL_ADDR=${CARDINAL_ADDR:-http://cardinal:3333}
+      - CARDINAL_NAMESPACE=0
+    entrypoint:
+      - "/bin/sh"
+      - "-ecx"
+      - >
+        /nakama/nakama migrate up --database.address postgres:localdb@postgres:5432/nakama &&
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:localdb@postgres:5432/nakama        
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    expose:
+      - "7349"
+      - "7350"
+      - "7351"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7350/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    links:
+      - "postgres:db"
+    ports:
+      - "7349:7349"
+      - "7350:7350"
+      - "7351:7351"
+volumes:
+  data:

--- a/magefiles/prereq.go
+++ b/magefiles/prereq.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/magefile/mage/sh"
 )

--- a/magefiles/prereq.go
+++ b/magefiles/prereq.go
@@ -11,12 +11,6 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-const (
-	goprivateEnv            = "GOPRIVATE"
-	goprivateURLArgusLabs   = "github.com/argus-labs"
-	goprivateURLWorldEngine = goprivateURLArgusLabs + "/world-engine"
-)
-
 // allOutput runs the command and returns the stdout and stderr. Nothing is printed to stdout and stderr.
 func allOutput(cmd string, args ...string) (out string, err error) {
 	outWriter, errWriter := &bytes.Buffer{}, &bytes.Buffer{}
@@ -48,16 +42,6 @@ func checkPrereq(verbose bool) error {
 			fmt.Println("success")
 		}
 	}
-
-	check(goprivateEnv, func() error {
-		out, err := allOutput("go", "env", goprivateEnv)
-		if err != nil {
-			return fmt.Errorf("problem getting env variable %q", goprivateEnv)
-		} else if !strings.Contains(out, goprivateURLArgusLabs) {
-			return fmt.Errorf("the env variable %q should contain %q or %q", goprivateEnv, goprivateURLArgusLabs, goprivateURLWorldEngine)
-		}
-		return nil
-	})
 
 	check("Docker", func() error {
 		if _, err := allOutput("docker", "-v"); err != nil {


### PR DESCRIPTION
## Changes:
- CI running build & test pipeline
- CI running release docker images build to GCP Artifact Registry
- Mage check - remove GOPRIVATE env (as the `world-engine` repo is public now)
- Add `docker-compose-prebuilt.yml` & change Cardinal Dockerfile multistage build (for smaller images size)
- README - add how to run the `starter-game-template` with prebuilt docker images