### PR TITLE
feat(nakama): use tx receipts to automatically verify p…

### DIFF
--- a/nakama/persona_tag_storage.go
+++ b/nakama/persona_tag_storage.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// personaTagStorageObj contains persona tag information for a specific user, and keeps track of whether the
+// persona tag has been successfully registered with cardinal.
+type personaTagStorageObj struct {
+	PersonaTag string           `json:"persona_tag"`
+	Status     personaTagStatus `json:"status"`
+	Tick       uint64           `json:"tick"`
+	TxHash     string           `json:"tx_hash"`
+	// version is used with Nakama storage layer to allow for optimistic locking. Saving this storage
+	// object succeeds only if the passed in version matches the version in the storage layer.
+	// see https://heroiclabs.com/docs/nakama/concepts/storage/collections/#conditional-writes for more info.
+	version string `json:"-"`
+}
+
+type personaTagStatus string
+
+const (
+	personaTagStatusUnknown  personaTagStatus = "unknown"
+	personaTagStatusPending  personaTagStatus = "pending"
+	personaTagStatusAccepted personaTagStatus = "accepted"
+	personaTagStatusRejected personaTagStatus = "rejected"
+)
+
+// loadPersonaTagStorageObj loads the current user's persona tag storage object from Nakama's storage layer. The
+// "current user" comes from the user ID stored in the given context.
+func loadPersonaTagStorageObj(ctx context.Context, nk runtime.NakamaModule) (*personaTagStorageObj, error) {
+	userID, err := getUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	storeObjs, err := nk.StorageRead(ctx, []*runtime.StorageRead{
+		{
+			Collection: cardinalCollection,
+			Key:        personaTagKey,
+			UserID:     userID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(storeObjs) == 0 {
+		return nil, ErrorPersonaTagStorageObjNotFound
+	} else if len(storeObjs) > 1 {
+		return nil, fmt.Errorf("expected 1 storage object, got %d with values %v", len(storeObjs), storeObjs)
+	}
+	ptr, err := storageObjToPersonaTagStorageObj(storeObjs[0])
+	if err != nil {
+		return nil, err
+	}
+	return ptr, nil
+}
+
+// storageObjToPersonaTagStorageObj converts a generic Nakama StorageObject to a locally defined personaTagStorageObj.
+func storageObjToPersonaTagStorageObj(obj *api.StorageObject) (*personaTagStorageObj, error) {
+	var ptr personaTagStorageObj
+	if err := json.Unmarshal([]byte(obj.Value), &ptr); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal persona tag storage obj: %w", err)
+	}
+	ptr.version = obj.Version
+	return &ptr, nil
+}
+
+// attemptToUpdatePending attempts to change the given personaTagStorageObj's Status from "pending" to either "accepted"
+// or "rejected" by using cardinal as the source of truth. If the Status is not "pending", this call is a no-op.
+func (p *personaTagStorageObj) attemptToUpdatePending(ctx context.Context, nk runtime.NakamaModule) (*personaTagStorageObj, error) {
+	if p.Status != personaTagStatusPending {
+		return p, nil
+	}
+
+	verified, err := p.verifyPersonaTag(ctx)
+	if err == ErrorPersonaSignerUnknown {
+		// Leave the Status as pending.
+		return p, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if verified {
+		p.Status = personaTagStatusAccepted
+	} else {
+		p.Status = personaTagStatusRejected
+	}
+	// Attempt to save the updated Status to Nakama. One reason this can fail is that the underlying record was
+	// updated while this processing was going on. Whatever the reason, re-fetch this record from Nakama's storage.
+	if err := p.savePersonaTagStorageObj(ctx, nk); err != nil {
+		return loadPersonaTagStorageObj(ctx, nk)
+	}
+	return p, nil
+}
+
+// verifyPersonaTag queries cardinal to see if the signer address for the given persona tag matches Nakama's signer
+// address
+func (p *personaTagStorageObj) verifyPersonaTag(ctx context.Context) (verified bool, err error) {
+	gameSignerAddress, err := cardinalQueryPersonaSigner(ctx, p.PersonaTag, p.Tick)
+	if err != nil {
+		return false, err
+	}
+	nakamaSignerAddress := getSignerAddress()
+	return gameSignerAddress == nakamaSignerAddress, nil
+}
+
+// savePersonaTagStorageObj saves the given personaTagStorageObj to the Nakama DB for the current user.
+func (p *personaTagStorageObj) savePersonaTagStorageObj(ctx context.Context, nk runtime.NakamaModule) error {
+	userID, err := getUserID(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to get user ID: %w", err)
+	}
+	buf, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("unable to marshal persona tag storage object: %w", err)
+	}
+	write := &runtime.StorageWrite{
+		Collection:      cardinalCollection,
+		Key:             personaTagKey,
+		UserID:          userID,
+		Value:           string(buf),
+		Version:         p.version,
+		PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
+		PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
+	}
+
+	_, err = nk.StorageWrite(ctx, []*runtime.StorageWrite{write})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *personaTagStorageObj) toJSON() (string, error) {
+	buf, err := json.Marshal(p)
+	return string(buf), err
+}

--- a/nakama/persona_tag_verifier.go
+++ b/nakama/persona_tag_verifier.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// personaTagVerifier is a helper struct that asynchronously collects both persona tag registration requests (from
+// nakama) AND persona tag transaction receipts from cardinal. When the result of both systems has been recorded,
+// this struct attempts to update the user's PersonaTagStorageObj to reflect the success/failure of the claim persona
+// tag request.
+type personaTagVerifier struct {
+	// txHashToPending keeps track of the state of pending claim persona tag requests. A sync.Map is not required
+	// because all map updates happen in a single goroutine. Updates are transmitted to the goroutine
+	// via the receiptCh channel and the pendingCh channel.
+	txHashToPending map[string]pendingPersonaTagRequest
+	receiptCh       receiptChan
+	pendingCh       chan txHashAndUserID
+	nk              runtime.NakamaModule
+	logger          runtime.Logger
+}
+
+type pendingPersonaTagRequest struct {
+	lastUpdate time.Time
+	userID     string
+	status     personaTagStatus
+}
+
+type txHashAndUserID struct {
+	txHash string
+	userID string
+}
+
+const personaVerifierSessionName = "persona_verifier_session"
+
+func (p *personaTagVerifier) addPendingPersonaTag(userID, txHash string) {
+	p.pendingCh <- txHashAndUserID{
+		userID: userID,
+		txHash: txHash,
+	}
+}
+
+func initPersonaTagVerifier(logger runtime.Logger, nk runtime.NakamaModule, rd *receiptsDispatcher) (*personaTagVerifier, error) {
+	ptv := &personaTagVerifier{
+		txHashToPending: map[string]pendingPersonaTagRequest{},
+		receiptCh:       make(receiptChan, 100),
+		pendingCh:       make(chan txHashAndUserID),
+		nk:              nk,
+		logger:          logger,
+	}
+	rd.subscribe(personaVerifierSessionName, ptv.receiptCh)
+	go ptv.consume()
+	return ptv, nil
+}
+
+func (p *personaTagVerifier) consume() {
+	cleanupTick := time.Tick(time.Minute)
+	for {
+		var currTxHash string
+		select {
+		case now := <-cleanupTick:
+			p.cleanupStaleEntries(now)
+		case receipt := <-p.receiptCh:
+			currTxHash = p.handleReceipt(receipt)
+		case pending := <-p.pendingCh:
+			currTxHash = p.handlePending(pending)
+		}
+		if currTxHash == "" {
+			continue
+		}
+		continue
+		if err := p.attemptVerification(currTxHash); err != nil {
+			p.logger.Error("failed to verify persona tag: %v", err)
+		}
+	}
+}
+
+func (p *personaTagVerifier) cleanupStaleEntries(now time.Time) {
+	for key, val := range p.txHashToPending {
+		if diff := now.Sub(val.lastUpdate); diff > time.Minute {
+			delete(p.txHashToPending, key)
+		}
+	}
+}
+
+func (p *personaTagVerifier) handleReceipt(receipt *Receipt) string {
+	result, ok := receipt.Result["Success"]
+	if !ok {
+		return ""
+	}
+	success, ok := result.(bool)
+	if !ok {
+		return ""
+	}
+	pending := p.txHashToPending[receipt.TxHash]
+	pending.lastUpdate = time.Now()
+	if success {
+		pending.status = personaTagStatusAccepted
+	} else {
+		pending.status = personaTagStatusRejected
+	}
+	p.txHashToPending[receipt.TxHash] = pending
+	return receipt.TxHash
+}
+
+func (p *personaTagVerifier) handlePending(tuple txHashAndUserID) string {
+	pending := p.txHashToPending[tuple.txHash]
+	pending.lastUpdate = time.Now()
+	pending.userID = tuple.userID
+	p.txHashToPending[tuple.txHash] = pending
+	return tuple.txHash
+}
+
+func (p *personaTagVerifier) attemptVerification(txHash string) error {
+	pending, ok := p.txHashToPending[txHash]
+	if !ok || pending.userID == "" || pending.status == "" {
+		// We're missing a success/failure message from cardinal or the initial request from the
+		// user to claim a persona tag.
+		return nil
+	}
+	// We have both a user ID and a success message. Save this success/failure to nakama's storage system
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, runtime.RUNTIME_CTX_USER_ID, pending.userID)
+	ptr, err := loadPersonaTagStorageObj(ctx, p.nk)
+	if err != nil {
+		return fmt.Errorf("unable to get persona tag storage obj: %w", err)
+	}
+	if ptr.Status != personaTagStatusPending {
+		return fmt.Errorf("expected a pending persona tag status but got %q", ptr.Status)
+	}
+	ptr.Status = pending.status
+	if err := ptr.savePersonaTagStorageObj(ctx, p.nk); err != nil {
+		return fmt.Errorf("unable to set persona tag storage object: %w", err)
+	}
+	delete(p.txHashToPending, txHash)
+	p.logger.Debug("result of associating user %q with persona tag %q: %v", pending.userID, ptr.PersonaTag, pending.status)
+	return nil
+}

--- a/nakama/persona_tag_verifier.go
+++ b/nakama/persona_tag_verifier.go
@@ -71,7 +71,6 @@ func (p *personaTagVerifier) consume() {
 		if currTxHash == "" {
 			continue
 		}
-		continue
 		if err := p.attemptVerification(currTxHash); err != nil {
 			p.logger.Error("failed to verify persona tag: %v", err)
 		}


### PR DESCRIPTION
…ersona tag creation

Closes CAR-117

- Add a personaTagVerifier struct that uses tx receipts to verify whether a persona tag registration was accepted or rejected.
- refactor the personaTagStorageObj code into a dedicated source file
- Update the making of signed payloads and the 'show-persona' endpoint to check with cardinal to see if a persona tag has been accepted or rejected. This code path won't normally be used because the personaTagVerified system will do this automatically and asynchronously.


Testing:
`mage test` will run persona tag creation unit tests against nakama and cardinal. 
