### PR TITLE
chore(ci): fix update build go-version to 1.21.x

### DIFF
--- a/.github/workflows/backend-mage-pipeline.yaml
+++ b/.github/workflows/backend-mage-pipeline.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   REGISTRY_URL: us-docker.pkg.dev
-  
+
 jobs:
   mage-build-test:
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
- Hot fix CI update, previous PR https://github.com/Argus-Labs/starter-game-template/pull/3 was made when we used go version 1.20.x. This update changes that to 1.21.x.