### PR TITLE
fix(starter-game-template): Include replace directive when copying starter-game-template and use .gitignore when copying files

### DIFF
--- a/magefiles/copy.go
+++ b/magefiles/copy.go
@@ -3,83 +3,147 @@
 package main
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	ignore "github.com/sabhiram/go-gitignore"
+	"golang.org/x/mod/modfile"
 )
+
+func makeGitIgnore() (*ignore.GitIgnore, error) {
+	return ignore.CompileIgnoreFileAndLines(".gitignore",
+		".git",
+		"go.mod",
+		"go.sum")
+}
 
 // Copy copies this sample project to the <target> directory and initializes it with 'go mod init <modulePath>'.
 // The module path parameter should be set to your code's repository. See https://golang.org/ref/mod#go-mod-init
 // for more info about go mod.
 func Copy(target, modulePath string) error {
+	ignore, err := makeGitIgnore()
+	if err != nil {
+		return err
+	}
+
 	mg.Deps(exitMagefilesDir)
 	if err := os.MkdirAll(target, os.ModePerm); err != nil {
 		return err
 	}
+	fmt.Printf("copying files to %q\n", target)
 	walkErr := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if strings.HasSuffix(path, "go.mod") {
-			return nil
-		}
-		if strings.HasSuffix(path, "go.sum") {
-			return nil
-		}
-		if strings.Contains(path, "vendor") {
+		if ignore.MatchesPath(path) {
 			return nil
 		}
 		if info.IsDir() {
 			if err := os.MkdirAll(filepath.Join(target, path), os.ModePerm); err != nil {
-				return err
+				return mg.Fatalf(1, "failed to make path %q and %q", target, path)
 			}
 			return nil
 		}
 		source := filepath.Join(".", path)
 		dest := filepath.Join(target, path)
 		if err := sh.Copy(dest, source); err != nil {
-			return err
+			return mg.Fatalf(1, "copy failure: %v", err)
 		}
-
 		return nil
 	})
+
 	if walkErr != nil {
+		fmt.Printf("error during file walk: %v", walkErr)
 		return walkErr
 	}
 
+	replaceDirectives, err := getReplaceDirectives("cardinal/go.mod")
+	if err != nil {
+		return mg.Fatalf(1, "failed to get replace directives: %v", err)
+	}
+
 	if err := os.Chdir(target); err != nil {
+		return mg.Fatalf(1, "failed to change directory to %q: %v\n", target, err)
+	}
+
+	if err := goModInitAndTidy(modulePath, "nakama", nil); err != nil {
+		return err
+	}
+	if err := goModInitAndTidy(modulePath, "magefiles", nil); err != nil {
 		return err
 	}
 
-	if err := goModInit(modulePath, "nakama"); err != nil {
-		return err
-	}
-	if err := goModInit(modulePath, "cardinal"); err != nil {
-		return err
-	}
-	if err := goModInit(modulePath, "magefiles"); err != nil {
+	if err := goModInitAndTidy(modulePath, "cardinal", replaceDirectives); err != nil {
 		return err
 	}
 
+	fmt.Println("All done. SUCCESS!")
 	return nil
 }
 
-func goModInit(modulePath, component string) error {
+func goModInitAndTidy(modulePath, component string, replace []*modfile.Replace) error {
+	fmt.Printf("running 'go mod init' for %q\n", component)
+	fmt.Println()
 	if err := os.Chdir(component); err != nil {
-		return err
+		return mg.Fatalf(1, "chdir for %q failure: %v", component, err)
 	}
 	if err := sh.Run("go", "mod", "init", modulePath+"/"+component); err != nil {
-		return err
+		return mg.Fatalf(1, "go mod init for %q failure: %v", component, err)
 	}
+	if replace != nil {
+		fmt.Println("adding custom replace directives")
+		if err := addReplaceDirectiveToGoMod("go.mod", replace); err != nil {
+			return mg.Fatalf(1, "adding replace directive for %q failed: %v", component, err)
+		}
+		fmt.Println("successfully added custom replace directives")
+	}
+	fmt.Println("successfully ran 'go mod init'")
+	fmt.Printf("running 'go mod tidy' for %q\n", component)
+	fmt.Println()
 	if err := sh.Run("go", "mod", "tidy"); err != nil {
-		return err
+		return mg.Fatalf(1, "go mod tidy for %q failure: %v", component, err)
 	}
 	if err := os.Chdir(".."); err != nil {
+		return mg.Fatalf(1, "chdir .. for %q failure: %v", component, err)
+	}
+	fmt.Println("successfully ran 'go mod tidy'")
+	return nil
+}
+
+func getReplaceDirectives(file string) ([]*modfile.Replace, error) {
+	mod, err := getModFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return mod.Replace, nil
+}
+
+func addReplaceDirectiveToGoMod(file string, replace []*modfile.Replace) error {
+	mod, err := getModFile(file)
+	if err != nil {
 		return err
 	}
-	return nil
+	for _, r := range replace {
+		o, n := r.Old, r.New
+		if err := mod.AddReplace(o.Path, o.Version, n.Path, n.Version); err != nil {
+			return err
+		}
+	}
+	buf, err := mod.Format()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(file, buf, 0)
+}
+
+func getModFile(file string) (*modfile.File, error) {
+	buf, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return modfile.Parse(file, buf, nil)
 }

--- a/magefiles/copy.go
+++ b/magefiles/copy.go
@@ -25,12 +25,13 @@ func makeGitIgnore() (*ignore.GitIgnore, error) {
 // The module path parameter should be set to your code's repository. See https://golang.org/ref/mod#go-mod-init
 // for more info about go mod.
 func Copy(target, modulePath string) error {
+	mg.Deps(exitMagefilesDir)
+
 	ignore, err := makeGitIgnore()
 	if err != nil {
 		return err
 	}
 
-	mg.Deps(exitMagefilesDir)
 	if err := os.MkdirAll(target, os.ModePerm); err != nil {
 		return err
 	}

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,5 +1,9 @@
-module github.com/argus-labs/darkforest/backend/magefiles
+module github.com/argus-labs/starter-game-template/magefiles
 
-go 1.20
+go 1.21.0
 
-require github.com/magefile/mage v1.15.0
+require (
+	github.com/magefile/mage v1.15.0
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+	golang.org/x/mod v0.12.0
+)

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,2 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -1,3 +1,5 @@
+//go:build mage
+
 package main
 
 import (


### PR DESCRIPTION
Closes [WORLD-95](https://linear.app/arguslabs/issue/WORLD-95/running-mage-copy-in-the-wrong-directory-causes-issues)

Fix the `mage copy` command. Cardinal requires some `replace` directives that were not copied over from the source project. 

Use the .gitignore file to limit what files are copied instead of maintaining a custom list of rules.