### PR TITLE
feat(nakama): Add ability to build and run an instance of Nakama that lives in some other directory

### DIFF
--- a/.jsclient/main.mjs
+++ b/.jsclient/main.mjs
@@ -37,8 +37,19 @@ var appearOnline = true
 session = await socket.connect(session, appearOnline);
 
 console.log("session is", session)
+
+let result = await client.listMatches(session)
+
+let dec = new TextDecoder()
+socket.onmatchdata = (result) => {
+    console.log("tx receipt: ", dec.decode(result.data));
+}
+
 socket.onnotification = (notification) => {
   console.log("Received %o", notification);
   console.log("Notification content %o", notification.content);
 }
 
+let match_id = result.matches[0].match_id
+let match = await socket.joinMatch(match_id)
+console.log("i joined the match: ", match)

--- a/.jsclient/main.mjs
+++ b/.jsclient/main.mjs
@@ -37,16 +37,8 @@ var appearOnline = true
 session = await socket.connect(session, appearOnline);
 
 console.log("session is", session)
-
-let result = await client.listMatches(session)
-
-let dec = new TextDecoder()
-
 socket.onnotification = (notification) => {
   console.log("Received %o", notification);
   console.log("Notification content %o", notification.content);
 }
 
-let match_id = result.matches[0].match_id
-let match = await socket.joinMatch(match_id)
-console.log("i joined the match: ", match)

--- a/.jsclient/main.mjs
+++ b/.jsclient/main.mjs
@@ -41,8 +41,10 @@ console.log("session is", session)
 let result = await client.listMatches(session)
 
 let dec = new TextDecoder()
-socket.onmatchdata = (result) => {
-    console.log("tx receipt: ", dec.decode(result.data));
+
+socket.onnotification = (notification) => {
+  console.log("Received %o", notification);
+  console.log("Notification content %o", notification.content);
 }
 
 let match_id = result.matches[0].match_id

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ To start Nakama and Cardinal:
 mage start
 ```
 
+To start Nakama from a specific directory (e.g. world-engine/relay/nakama) as well as the Cardinal instance in this directory:
+```bash
+mage nakamaAt <path/to/nakama/dir>
+```
+
 To start ONLY Cardinal in dev mode (compatible with the Retool dashboard):
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - REDIS_MODE=normal
   nakama:
     platform: linux/amd64
-    build: ./nakama
+    build: ${PATH_TO_NAKAMA}
     depends_on:
       - postgres
       - cardinal

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -61,8 +61,26 @@ func Nakama() error {
 		return err
 	}
 	env := map[string]string{
-		"CARDINAL_ADDR": "http://host.docker.internal:3333",
+		"CARDINAL_ADDR":  "http://host.docker.internal:3333",
+		"PATH_TO_NAKAMA": "./nakama",
 	}
+	if err := sh.RunWithV(env, "docker", "compose", "up", "--build", "nakama"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// NakamaAt builds Nakama from the given path and starts Nakama and cardinal.
+func NakamaAt(path string) error {
+	mg.Deps(exitMagefilesDir)
+	if err := prepareDir(path); err != nil {
+		return err
+	}
+	env := map[string]string{
+		"CARDINAL_ADDR":  "http://host.docker.internal:3333",
+		"PATH_TO_NAKAMA": path,
+	}
+
 	if err := sh.RunWithV(env, "docker", "compose", "up", "--build", "nakama"); err != nil {
 		return err
 	}

--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -10,6 +10,10 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
+var (
+	environment = map[string]string{}
+)
+
 // Check verifies that various prerequisites are installed or configured on your machine
 func Check() error {
 	return checkPrereq(true)
@@ -17,7 +21,7 @@ func Check() error {
 
 // Clear deletes all the docker volumes
 func Clear() error {
-	if err := sh.RunV("docker", "compose", "down", "--volumes"); err != nil {
+	if err := sh.RunWithV(environment, "docker", "compose", "down", "--volumes"); err != nil {
 		return err
 	}
 	return nil
@@ -25,13 +29,14 @@ func Clear() error {
 
 // Test runs the test suite
 func Test() error {
+	environment["PATH_TO_NAKAMA"] = "./nakama"
 	mg.Deps(exitMagefilesDir)
 	mg.Deps(Clear)
 
 	if err := prepareDirs("testsuite", "cardinal", "nakama"); err != nil {
 		return err
 	}
-	if err := sh.RunV("docker", "compose", "up", "--build", "--abort-on-container-exit", "--exit-code-from", "testsuite", "--attach", "testsuite"); err != nil {
+	if err := sh.RunWithV(environment, "docker", "compose", "up", "--build", "--abort-on-container-exit", "--exit-code-from", "testsuite", "--attach", "testsuite"); err != nil {
 		return err
 	}
 	return nil

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -4,9 +4,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
+
+	"github.com/magefile/mage/sh"
 )
 
 func prepareDirs(dirs ...string) error {
@@ -19,6 +20,10 @@ func prepareDirs(dirs ...string) error {
 }
 
 func prepareDir(dir string) error {
+	originDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 	if err := os.Chdir(dir); err != nil {
 		return err
 	}
@@ -31,7 +36,7 @@ func prepareDir(dir string) error {
 	if err := sh.Run("go", "mod", "vendor"); err != nil {
 		return err
 	}
-	if err := os.Chdir(".."); err != nil {
+	if err := os.Chdir(originDir); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Adds the `mage nakamaAt` target which takes in the path to a Nakama directory. Mage will build and run the instance of Nakama at the target directory. This will be helpful during development on the (world-engine/relay/nakama)[https://github.com/Argus-Labs/world-engine/tree/main/relay/nakama] project. A user can run the starter-game-template while using a custom-build version of Nakama.

In addition, the .jsclient has been adjusted to use Nakama notifications instead of match data for the receiving of transaction results.

To test, run:

```
mage nakamaAt <path/to/world-engine/relay/nakama>
```

And everything should start up normally.
