### PR TITLE
chore(mage): don't build nakama

### DIFF
--- a/magefiles/main.go
+++ b/magefiles/main.go
@@ -72,7 +72,7 @@ func Nakama() error {
 // Start starts Nakama and cardinal
 func Start() error {
 	mg.Deps(exitMagefilesDir)
-	if err := prepareDirs("cardinal", "nakama"); err != nil {
+	if err := prepareDirs("cardinal"); err != nil {
 		return err
 	}
 	if err := sh.RunV("docker", "compose", "up", "--build", "cardinal", "nakama"); err != nil {


### PR DESCRIPTION
We're no longer using a nakama directory in this repo, this fixes the mage file to not try to build that dir