### PR TITLE
chore(db): change Nakama PostgresDB to CockroachDB, use env var for DB_PASSWORD

### DIFF
--- a/.debug/docker-compose-debug.yml
+++ b/.debug/docker-compose-debug.yml
@@ -1,24 +1,27 @@
 version: "3"
 services:
-  postgres:
-    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
+  cockroachdb:
+    # Only use cockroachdb single-node clusters for non-production environment
+    image: cockroachdb/cockroach:latest-v23.1
+    command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/,size=20%
+    restart: "no"
     environment:
-      - POSTGRES_DB=nakama
-      - POSTGRES_PASSWORD=localdb
+      - COCKROACH_DATABASE=nakama
+      - COCKROACH_USER=root
+      - COCKROACH_PASSWORD=${DB_PASSWORD:-development}
+    volumes:
+      - data:/var/lib/cockroach
     expose:
       - "8080"
-      - "5432"
-    image: postgres:12.2-alpine
+      - "26257"
     ports:
-      - "5432:5432"
+      - "26257:26257"
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "nakama"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
       interval: 3s
       timeout: 3s
       retries: 5
-    volumes:
-      - data:/var/lib/postgresql/data
   redis: # This doesn't have the correct persistence settings. Don't use on for prod.
     image: redis:latest
     command: redis-server # TODO: This runs without password. Don't use for prod.
@@ -51,17 +54,20 @@ services:
     platform: linux/amd64
     image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama@sha256:60737f1de75b5e1dfe0f1eb557ebf6f8c691cc2812950dc4e3132242709ddc09
     depends_on:
-      - postgres
-      - cardinal
+      cockroachdb:
+        condition: service_healthy
+      cardinal:
+        condition: service_started
     environment:
       - CARDINAL_ADDR=${CARDINAL_ADDR:-cardinal:3333}
       - CARDINAL_NAMESPACE=world
+      - DB_PASSWORD=${DB_PASSWORD:-development}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
-        /nakama/nakama migrate up --database.address postgres:localdb@postgres:5432/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:localdb@postgres:5432/nakama
+        /nakama/nakama migrate up --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama &&
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama
     extra_hosts:
       - "host.docker.internal:host-gateway"
     expose:
@@ -73,8 +79,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    links:
-      - "postgres:db"
     ports:
       - "7349:7349"
       - "7350:7350"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,27 @@
 version: "3"
 services:
-  postgres:
-    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
+  cockroachdb:
+    # Only use cockroachdb single-node clusters for non-production environment
+    image: cockroachdb/cockroach:latest-v23.1
+    command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/,size=20%
+    restart: "no"
     environment:
-      - POSTGRES_DB=nakama
-      - POSTGRES_PASSWORD=localdb
+      - COCKROACH_DATABASE=nakama
+      - COCKROACH_USER=root
+      - COCKROACH_PASSWORD=${DB_PASSWORD:-development}
+    volumes:
+      - data:/var/lib/cockroach
     expose:
       - "8080"
-      - "5432"
-    image: postgres:12.2-alpine
+      - "26257"
     ports:
-      - "5432:5432"
+      - "26257:26257"
       - "8080:8080"
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "postgres", "-d", "nakama" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
       interval: 3s
       timeout: 3s
       retries: 5
-    volumes:
-      - data:/var/lib/postgresql/data
   redis: # This doesn't have the correct persistence settings. Don't use on for prod.
     image: redis:latest
     command: redis-server # TODO: This runs without password. Don't use for prod.
@@ -43,17 +46,20 @@ services:
     platform: linux/amd64
     image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama@sha256:60737f1de75b5e1dfe0f1eb557ebf6f8c691cc2812950dc4e3132242709ddc09
     depends_on:
-      - postgres
-      - cardinal
+      cockroachdb:
+        condition: service_healthy
+      cardinal:
+        condition: service_started
     environment:
       - CARDINAL_ADDR=${CARDINAL_ADDR:-cardinal:3333}
       - CARDINAL_NAMESPACE=world
+      - DB_PASSWORD=${DB_PASSWORD:-development}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
-        /nakama/nakama migrate up --database.address postgres:localdb@postgres:5432/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:localdb@postgres:5432/nakama        
+        /nakama/nakama migrate up --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama &&
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama
     extra_hosts:
       - "host.docker.internal:host-gateway"
     expose:
@@ -65,8 +71,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    links:
-      - "postgres:db"
     ports:
       - "7349:7349"
       - "7350:7350"


### PR DESCRIPTION
Closes: #DEVOP-112 #DEVOP-113

## What is the purpose of the change

> 
- Nakama doesn't officially support Postgres (see https://heroiclabs.com/docs/nakama/getting-started/install/linux/#cockroachdb), it's for development environments only.
- We should switch it to CockroachDB which is officially supported and with queries optimized for its storage engine.

## Brief Changelog

- _Change Docker Compose setup to use CockroachDB for development (Single-node clusters)_
- _Fix makefile_
- _Use $DB_PASSWORD as env variable instead of plain text, the default value is "development"._