### PR TITLE
chore: add world evm and celestia devnet to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,14 @@ services:
   evm:
     container_name: evm_base_shard
     environment:
-      - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-}
-      - DA_BASE_URL=http://celestia-devnet:26658
-      - DA_NAMESPACE_ID=67480c4a88c4d12935d4
-      - CHAIN_ID=world-engine
+      - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-} # this value must come from the celestia client.
+      - DA_BASE_URL=${DA_BASE_URL:-http://celestia-devnet:26658}
+      - DA_NAMESPACE_ID=${DA_NAMESPACE_ID:-67480c4a88c4d12935d4}
+      - CHAIN_ID=${CHAIN_ID:-world-engine}
         # this is a test mnemonic and should not be used in production. this mnemonic can be overwritten using the KEY_MNEMONIC environment variable
       - KEY_MNEMONIC=${KEY_MNEMONIC:-enact adjust liberty squirrel bulk ticket invest tissue antique window thank slam unknown fury script among bread social switch glide wool clog flag enroll}
-      - FAUCET_ADDR=world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5
-      - BLOCK_TIME=3s
+      - FAUCET_ADDR=${FAUCET_ADDR:-world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5}
+      - BLOCK_TIME=${BLOCK_TIME:-3s}
     image: us-docker.pkg.dev/argus-labs/world-engine/chain:latest
     expose:
       - "1317"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   celestia-devnet:
     container_name: celestia_devnet
-    image: ghcr.io/rollkit/local-celestia-devnet:v0.11.0-rc12
+    image: ghcr.io/rollkit/local-celestia-devnet:v0.12.1
     restart: on-failure
     ports:
       - "26657"
@@ -14,35 +14,26 @@ services:
     container_name: evm_base_shard
     environment:
       - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-}
-      - VALIDATOR_NAME=${VALIDATOR_NAME:-}
-      - CHAIN_ID=${CHAIN_ID-}
-      - KEY_NAME=${KEY_NAME:-}
-      - KEY_MNEMONIC=${KEY_MNEMONIC:-}
-      - KEY_BACKEND=${KEY_BACKEND:-}
-      - TOKEN_AMOUNT=${TOKEN_AMOUNT:-}
-      - STAKING_AMOUNT=${STAKING_AMOUNT:-}
-      - MIN_GAS_PRICE=${MIN_GAS_PRICE:-}
-      - TOKEN_DENOM=${TOKEN_DENOM:-}
-      - FAUCET_ADDR=${FAUCET_ADDR:-}
-      - DA_BASE_URL=${DA_BASE_URL:-}
-      - DA_BLOCK_HEIGHT=${DA_BLOCK_HEIGHT:-}
-      - BLOCK_TIME=${BLOCK_TIME:-}
-      - DA_NAMESPACE_ID=${DA_NAMESPACE_ID:-}
-      - DA_CONFIG=${DA_CONFIG:-}
+      - DA_BASE_URL=http://celestia-devnet:26658
+      - DA_NAMESPACE_ID=67480c4a88c4d12935d4
+      - CHAIN_ID=world-engine
+        # this is a test mnemonic and should not be used in production. this mnemonic can be overwritten using the KEY_MNEMONIC environment variable
+      - KEY_MNEMONIC=${KEY_MNEMONIC:-enact adjust liberty squirrel bulk ticket invest tissue antique window thank slam unknown fury script among bread social switch glide wool clog flag enroll}
+      - FAUCET_ADDR=world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5
+      - BLOCK_TIME=3s
     image: us-docker.pkg.dev/argus-labs/world-engine/chain:latest
     expose:
       - "1317"
       - "26657"
       - "9090"
       - "9601"
+      - "8545"
     ports:
       - "1317:1317"
       - "26657:26657"
       - "9090:9090"
       - "9601:9601"
       - "8545:8545"
-    depends_on:
-      - celestia-devnet
 
   cockroachdb:
     # Only use cockroachdb single-node clusters for non-production environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,14 @@ services:
   evm:
     container_name: evm_base_shard
     environment:
-      - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-} # this value must come from the celestia client.
+      - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-} # this value must come from the celestia client. https://docs.celestia.org/developers/node-tutorial#auth-token
       - DA_BASE_URL=${DA_BASE_URL:-http://celestia-devnet:26658}
       - DA_NAMESPACE_ID=${DA_NAMESPACE_ID:-67480c4a88c4d12935d4}
       - CHAIN_ID=${CHAIN_ID:-world-engine}
         # this is a test mnemonic and should not be used in production. this mnemonic can be overwritten using the KEY_MNEMONIC environment variable
       - KEY_MNEMONIC=${KEY_MNEMONIC:-enact adjust liberty squirrel bulk ticket invest tissue antique window thank slam unknown fury script among bread social switch glide wool clog flag enroll}
       - FAUCET_ADDR=${FAUCET_ADDR:-world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5}
-      - BLOCK_TIME=${BLOCK_TIME:-3s}
+      - BLOCK_TIME=${BLOCK_TIME:-1s}
     image: us-docker.pkg.dev/argus-labs/world-engine/chain:latest
     expose:
       - "1317"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,49 @@
 version: "3"
 services:
+  celestia-devnet:
+    container_name: celestia_devnet
+    image: ghcr.io/rollkit/local-celestia-devnet:v0.11.0-rc12
+    restart: on-failure
+    ports:
+      - "26657"
+      - "26658"
+      - "26659"
+      - "9090"
+
+  evm:
+    container_name: evm_base_shard
+    environment:
+      - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-}
+      - VALIDATOR_NAME=${VALIDATOR_NAME:-}
+      - CHAIN_ID=${CHAIN_ID-}
+      - KEY_NAME=${KEY_NAME:-}
+      - KEY_MNEMONIC=${KEY_MNEMONIC:-}
+      - KEY_BACKEND=${KEY_BACKEND:-}
+      - TOKEN_AMOUNT=${TOKEN_AMOUNT:-}
+      - STAKING_AMOUNT=${STAKING_AMOUNT:-}
+      - MIN_GAS_PRICE=${MIN_GAS_PRICE:-}
+      - TOKEN_DENOM=${TOKEN_DENOM:-}
+      - FAUCET_ADDR=${FAUCET_ADDR:-}
+      - DA_BASE_URL=${DA_BASE_URL:-}
+      - DA_BLOCK_HEIGHT=${DA_BLOCK_HEIGHT:-}
+      - BLOCK_TIME=${BLOCK_TIME:-}
+      - DA_NAMESPACE_ID=${DA_NAMESPACE_ID:-}
+      - DA_CONFIG=${DA_CONFIG:-}
+    image: us-docker.pkg.dev/argus-labs/world-engine/chain:latest
+    expose:
+      - "1317"
+      - "26657"
+      - "9090"
+      - "9601"
+    ports:
+      - "1317:1317"
+      - "26657:26657"
+      - "9090:9090"
+      - "9601:9601"
+      - "8545:8545"
+    depends_on:
+      - celestia-devnet
+
   cockroachdb:
     # Only use cockroachdb single-node clusters for non-production environment
     image: cockroachdb/cockroach:latest-v23.1
@@ -22,6 +66,7 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
+
   redis: # This doesn't have the correct persistence settings. Don't use on for prod.
     image: redis:latest
     command: redis-server # TODO: This runs without password. Don't use for prod.
@@ -30,6 +75,7 @@ services:
     ports:
       - "6379:6379"
     restart: always
+
   cardinal:
     build: ./cardinal
     depends_on:
@@ -42,6 +88,7 @@ services:
       - CARDINAL_PORT=3333
       - REDIS_ADDR=redis:6379
       - REDIS_MODE=normal
+
   nakama:
     platform: linux/amd64
     image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama@sha256:60737f1de75b5e1dfe0f1eb557ebf6f8c691cc2812950dc4e3132242709ddc09
@@ -76,5 +123,6 @@ services:
       - "7350:7350"
       - "7351:7351"
     restart: unless-stopped
+
 volumes:
   data:


### PR DESCRIPTION
adds evm and celestia to docker compose. this allows us to spin up the stack via world-cli.