### PR TITLE
chore: Add docker-compose - restart unless-stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     restart: always
   cardinal:
     build: ./cardinal
+    restart: unless-stopped
     depends_on:
       - redis
     expose:
@@ -45,6 +46,7 @@ services:
   nakama:
     platform: linux/amd64
     image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama@sha256:60737f1de75b5e1dfe0f1eb557ebf6f8c691cc2812950dc4e3132242709ddc09
+    restart: unless-stopped
     depends_on:
       cockroachdb:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
     restart: always
   cardinal:
     build: ./cardinal
-    restart: unless-stopped
     depends_on:
       - redis
     expose:
@@ -43,10 +42,10 @@ services:
       - CARDINAL_PORT=3333
       - REDIS_ADDR=redis:6379
       - REDIS_MODE=normal
+    restart: unless-stopped
   nakama:
     platform: linux/amd64
     image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama@sha256:60737f1de75b5e1dfe0f1eb557ebf6f8c691cc2812950dc4e3132242709ddc09
-    restart: unless-stopped
     depends_on:
       cockroachdb:
         condition: service_healthy


### PR DESCRIPTION
Closes: DEVOP-116

Changes:
- Add `restart: unless-stopped` into docker-compose services.