### PR TITLE
build: add router key env var on docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - REDIS_ADDRESS=${REDIS_ADDRESS:-redis:6379}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - REDIS_MODE=normal
+      - ROUTER_KEY=${ROUTER_KEY}
     restart: unless-stopped
 
   cardinal-debug:
@@ -46,6 +47,7 @@ services:
       - REDIS_ADDRESS=${REDIS_ADDRESS:-redis:6379}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - REDIS_MODE=normal
+      - ROUTER_KEY=${ROUTER_KEY}
     restart: unless-stopped
 
   evm:
@@ -63,6 +65,7 @@ services:
       - FAUCET_ADDR=${FAUCET_ADDR:-world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5}
       # Note, ":-" signals a default value of "1s", NOT negative 1 second.
       - BLOCK_TIME=${BLOCK_TIME:-1s}
+      - ROUTER_KEY=${ROUTER_KEY}
     image: us-docker.pkg.dev/argus-labs/world-engine/chain:latest
     expose:
       - "1317"


### PR DESCRIPTION
Closes: XXX

## Overview

Add ROUTER_KEY on dokcer compose
- cardinal
- cardinal-debug
- evm

World CLI will set ROUTER_KEY to env var, and sgt need to add to docker env var