### PR TITLE
chore: add .editor/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ $RECYCLE.BIN/
 # Node
 /.jsclient/node_modules
 yarn-error.log
+
+# cardinal editor dir
+.editor


### PR DESCRIPTION
closes: WORLD-1042

# Overview
add `.editor/` to .gitignore as this isn't required to be tracked in git, similar to `node_modules`.

# Testing and Vefifying
Manual verification
