### PR TITLE
fix: update nakama docker image url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   nakama:
     platform: linux/amd64
-    image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama:v1.2.3
+    image: ghcr.io/argus-labs/world-engine-nakama:1.2.5
     container_name: nakama
     depends_on:
       nakama-db:


### PR DESCRIPTION
Closes: WORLD-XXX

## Overview

Update nakama docker image url

## Brief Changelog

- Update nakama docker image url in docker-compose.yml

## Testing and Verifying

- Manually tested using world cli `world cardinal start`


