### PR TITLE
fix: add nakama-debug on docker-compose to fix debug mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - REDIS_MODE=normal
       - ROUTER_KEY=${ROUTER_KEY}
     restart: unless-stopped
-
+  
   cardinal-debug:
     container_name: cardinal-debug
     build:
@@ -85,10 +85,8 @@ services:
     image: ghcr.io/argus-labs/world-engine-nakama:1.2.5
     container_name: nakama
     depends_on:
-      nakama-db:
-        condition: service_healthy
-      cardinal:
-        condition: service_started
+      - "nakama-db"
+      - "${CARDINAL_CONTAINER:-cardinal}"
     environment:
       - CARDINAL_ADDR=${CARDINAL_ADDR:-cardinal:4040}
       - CARDINAL_NAMESPACE=${CARDINAL_NAMESPACE}


### PR DESCRIPTION
Adding nakama-debug on docker-compose.yml to fix running cardinal on debug mode `--debug` flag. 

Previously `cardinal-debug` container need `nakama` but `nakama` depends-on `cardinal` not `cardinal-debug` so this results an error when running cardinal with debug mode.

**
~~Updated using two docker-compose file.
CLI will run with args -f docker-compose.yml -f docker-compose.debug.yml up in --debug mode and it will override the first docker-compose file with the second one.~~

Updated using short syntax with envar passed from world-cli

