### PR TITLE
fix: remove attach from nakama db docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,6 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
-    attach: false
     networks:
       - world-engine
 


### PR DESCRIPTION
**Overview**

Removing attach on nakama-db docker compose, it causing error on unit test world cli.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/179c5ec9-1d6f-4966-8e3a-2d131934ed66.png)

