### PR TITLE
fix: exposed ports and security on docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     container_name: cardinal
     environment:
       - REDIS_ADDRESS=redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-very_unsafe_password_replace_me}
       - BASE_SHARD_SEQUENCER_ADDRESS=evm:9601
     build:
       target: runtime
@@ -20,6 +21,7 @@ services:
     container_name: cardinal-debug
     environment:
       - REDIS_ADDRESS=redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-very_unsafe_password_replace_me}
       - BASE_SHARD_SEQUENCER_ADDRESS=evm:9601
     build:
       target: runtime-debug
@@ -31,7 +33,6 @@ services:
       - redis
     expose:
       - "4040"
-      - "40000"
     ports:
       - "4040:4040"
       - "40000:40000"
@@ -120,11 +121,7 @@ services:
     volumes:
       - data:/var/lib/cockroach
     expose:
-      - "8080"
       - "26257"
-    ports:
-      - "26257:26257"
-      - "8080:8080"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/health?ready=1" ]
       interval: 3s
@@ -137,12 +134,9 @@ services:
   redis:
     container_name: redis
     image: redis:latest
-    environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:-very_unsafe_password_replace_me}"]
     expose:
       - "6379"
-    ports:
-      - "6379:6379"
     attach: false
     restart: unless-stopped
     volumes:
@@ -163,8 +157,8 @@ services:
       retries: 20
     ports:
       - "26657"
-      - "26658:26658"
-      - "26659:26659"
+      - "26658"
+      - "26659"
       - "9090"
 
 volumes:

--- a/world.toml
+++ b/world.toml
@@ -3,11 +3,11 @@ CARDINAL_NAMESPACE = "defaultnamespace"     # A namespace must be a unique alpha
 CARDINAL_ROLLUP_ENABLED = "false"           # Enables rollup mode
 CARDINAL_LOG_LEVEL = "info"                 # Must be one of (debug, info, warn, error, fatal, panic, disabled, trace)
 CARDINAL_LOG_PRETTY= "true"
-REDIS_ADDRESS = "localhost:6379"                 # UNIX Domain Socket or TCP Address
-REDIS_PASSWORD = ""                               # If TCP address is used, setting a password is encouraged in production
-TELEMETRY_TRACE_ENABLED = false                   # Enables OpenTelemetry tracing
-TELEMETRY_PROFILER_ENABLED = false                # Enables Datadog profiler
-BASE_SHARD_SEQUENCER_ADDRESS = "localhost:9601"   # Required if rollup mode is enabled
+REDIS_ADDRESS = "localhost:6379"                   # UNIX Domain Socket or TCP Address
+REDIS_PASSWORD = "very_unsafe_password_replace_me" # If TCP address is used, setting a password is encouraged in production
+TELEMETRY_TRACE_ENABLED = false                    # Enables OpenTelemetry tracing
+TELEMETRY_PROFILER_ENABLED = false                 # Enables Datadog profiler
+BASE_SHARD_SEQUENCER_ADDRESS = "localhost:9601"    # Required if rollup mode is enabled
 BASE_SHARD_ROUTER_KEY = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01" # Secure auth token for game shard
 
 [evm]
@@ -28,3 +28,15 @@ ENABLE_ALLOWLIST="false" # enable nakama's beta key feature. you can generate an
 # The number of undelivered notifications Nakama will allow before shutting down a connectino to a client.
 # See https://heroiclabs.com/docs/nakama/getting-started/configuration/#socket.outgoing_queue_size 
 OUTGOING_QUEUE_SIZE=64
+# Enables tracing within Nakama, which integrates with external tracing tools such as Jaeger for visualizing system performance.
+NAKAMA_TRACE_ENABLED = true   
+# Enables metrics collection within Nakama, integrating with Prometheus for system metrics tracking.
+NAKAMA_METRICS_ENABLED = true
+# Trace sample rate. valid values are between 0.0 to 1.0 inclusive. This is a float value.
+NAKAMA_TRACE_SAMPLE_RATE = 0.6
+# Prometheus scraping interval in seconds.
+NAKAMA_METRICS_INTERVAL = 30
+
+[common]
+# A key used by both Cardinal and EVM to coordinate activities
+ROUTER_KEY = "router_key"


### PR DESCRIPTION
Closes: WORLD-1215, WORLD-1210

## Overview

Disable exposed port for redis, nakamadb, and celestia

## Brief Changelog

- Remove exposed port
- Add password for redis

## Testing and Verifying

- Run using world cli
- Run using docker compose for every container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for enhanced tracing and metrics collection in Nakama.
	- Added a new key for coordination between Cardinal and EVM.
- **Improvements**
	- Updated Redis password handling for improved security.
- **Configuration Changes**
	- Adjusted port mappings and environment variables across multiple services for better management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->