### PR TITLE
feat: update nakama to v1.4.0 and evm to v1.5.1 on docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   evm:
     container_name: evm
-    image: ghcr.io/argus-labs/world-engine-evm:1.4.1
+    image: ghcr.io/argus-labs/world-engine-evm:1.5.1
     environment:
       ## Env vars reference: https://github.com/Argus-Labs/world-engine/blob/main/evm/README.md
       ## Get AUTH_TOKEN from celestia_devnet container: `$(docker exec $(docker ps -q) celestia bridge auth admin --node.store /home/celestia/bridge`
@@ -71,8 +71,7 @@ services:
 
   nakama:
     container_name: nakama
-    platform: linux/amd64
-    image: ghcr.io/argus-labs/world-engine-nakama:1.2.7
+    image: ghcr.io/argus-labs/world-engine-nakama:1.4.0
     depends_on:
       - "nakama-db"
       - "${CARDINAL_CONTAINER:-cardinal}"


### PR DESCRIPTION
Closes: WORLD-XXX

## Overview

Update nakama to v1.4.0 and evm to v1.5.1

## Brief Changelog

- update nakama and evm version on docker compose file

## Testing and Verifying

Tested manually using `docker compose up` command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `cardinal-debug` service with enhanced capabilities and an additional port.
  
- **Updates**
	- Updated image versions for `evm` and `nakama` services to improve performance and security.
	- Added health check configuration for the `celestia-devnet` service to ensure reliability.
  
- **Configuration Changes**
	- Adjusted `redis` service to require a password for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->